### PR TITLE
Add minimal Node.js skeleton for Chinese learning app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# chineselearning
+# Chinese Learning
+
+Simple Node.js application skeleton to guide learners of Chinese. It exposes routes for grammar, reading, listening, writing, character practice, and pinyin. The writing section optionally integrates with a free Hugging Face model to suggest corrections.
+
+## Usage
+
+1. Ensure Node.js 18 or later is installed.
+2. (Optional) set the environment variable `HF_API_TOKEN` with a Hugging Face API token.
+3. Start the server:
+   ```bash
+   npm start
+   ```
+4. Open [http://localhost:3000](http://localhost:3000) in your browser and navigate through the sections.
+
+## Development Notes
+
+Attempts to install external packages like Express or Axios failed due to access restrictions, so the implementation relies solely on built-in Node.js modules.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "chineselearning",
+  "version": "1.0.0",
+  "description": "Simple web app skeleton for Chinese learning with AI corrections.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,108 @@
+const http = require('http');
+const { URL } = require('url');
+
+const PORT = process.env.PORT || 3000;
+
+async function correctText(text) {
+  const token = process.env.HF_API_TOKEN;
+  if (!token) {
+    return { corrected: text, note: 'HF_API_TOKEN not set - returning original text.' };
+  }
+  try {
+    const response = await fetch('https://api-inference.huggingface.co/models/uer/gpt2-chinese-cluecorpussmall', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ inputs: text })
+    });
+    if (!response.ok) {
+      return { corrected: text, note: `Model request failed: ${response.status}` };
+    }
+    const data = await response.json();
+    if (Array.isArray(data) && data[0]?.generated_text) {
+      return { corrected: data[0].generated_text };
+    }
+    return { corrected: text, note: 'Model response in unexpected format.' };
+  } catch (err) {
+    return { corrected: text, note: `Model request error: ${err.message}` };
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === 'GET' && url.pathname === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(`<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Chinese Learning</title></head>
+<body>
+<h1>Chinese Learning</h1>
+<ul>
+<li><a href="/grammar">Grammar</a></li>
+<li><a href="/reading">Reading</a></li>
+<li><a href="/listening">Listening</a></li>
+<li><a href="/writing">Writing</a></li>
+<li><a href="/characters">Characters</a></li>
+<li><a href="/pinyin">Pinyin</a></li>
+</ul>
+</body></html>`);
+  } else if (req.method === 'GET' && url.pathname === '/grammar') {
+    res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Grammar section placeholder');
+  } else if (req.method === 'GET' && url.pathname === '/reading') {
+    res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Reading section placeholder');
+  } else if (req.method === 'GET' && url.pathname === '/listening') {
+    res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Listening section placeholder');
+  } else if (req.method === 'GET' && url.pathname === '/characters') {
+    res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Characters writing section placeholder');
+  } else if (req.method === 'GET' && url.pathname === '/pinyin') {
+    res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Pinyin section placeholder');
+  } else if (url.pathname === '/writing') {
+    if (req.method === 'POST') {
+      let body = '';
+      req.on('data', chunk => body += chunk);
+      req.on('end', async () => {
+        let text = '';
+        try {
+          if (req.headers['content-type'] === 'application/json') {
+            const json = JSON.parse(body || '{}');
+            text = json.text || '';
+          } else {
+            const params = new URLSearchParams(body);
+            text = params.get('text') || '';
+          }
+        } catch (e) {
+          text = '';
+        }
+        const result = await correctText(text);
+        res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify(result));
+      });
+    } else {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(`<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Writing</title></head>
+<body>
+<form method="POST" action="/writing">
+<textarea name="text" rows="4" cols="50"></textarea><br/>
+<button type="submit">Submit</button>
+</form>
+</body></html>`);
+    }
+  } else {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node.js server exposing grammar, reading, listening, writing, character, and pinyin sections
- integrate optional Hugging Face model for writing corrections
- document setup and usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895dd93367c83259dddb9fded33e5fb